### PR TITLE
Protect against frontrunning

### DIFF
--- a/src/DefaultInflationManager.sol
+++ b/src/DefaultInflationManager.sol
@@ -42,7 +42,8 @@ contract DefaultInflationManager is Initializable, Ownable2StepUpgradeable, IDef
         address treasury_,
         address owner_
     ) external initializer {
-        require(DEPLOYER == msg.sender, "ONLY_DEPLOYER");
+        // prevent front-running since we can't initialize on proxy deployment
+        if (DEPLOYER != msg.sender) revert();
         if (
             token_ == address(0) ||
             migration_ == address(0) ||

--- a/test/DefaultInflationManager.t.sol
+++ b/test/DefaultInflationManager.t.sol
@@ -85,7 +85,7 @@ contract DefaultInflationManagerTest is Test {
         );
 
         vm.prank(address(seed));
-        vm.expectRevert("ONLY_DEPLOYER");
+        vm.expectRevert();
         DefaultInflationManager(proxy).initialize(params[0], params[1], params[2], params[3], params[4]);
 
         params[seed % params.length] = address(0); // any one is zero addr


### PR DESCRIPTION
The initialisation of the Inflation Manager can be frontrun / griefed during deployment. This PR adds a check whether the deployer is also initialising the contract.