### PR TITLE
PIP-26: Transition from MATIC to POL Validator Rewards

### DIFF
--- a/src/DefaultEmissionManager.sol
+++ b/src/DefaultEmissionManager.sol
@@ -68,10 +68,12 @@ contract DefaultEmissionManager is Ownable2StepUpgradeable, IDefaultEmissionMana
         emit TokenMint(amountToMint, msg.sender);
 
         IPolygonEcosystemToken _token = token;
+        
         _token.mint(address(this), amountToMint);
+
         _token.safeTransfer(treasury, treasuryAmt);
-        // backconvert POL to MATIC before sending to StakeManager
-        migration.unmigrateTo(stakeManager, stakeManagerAmt);
+
+        _token.safeTransfer(stakeManager, stakeManagerAmt);
     }
 
     /// @inheritdoc IDefaultEmissionManager

--- a/test/DefaultEmissionManager.t.sol
+++ b/test/DefaultEmissionManager.t.sol
@@ -125,7 +125,6 @@ contract DefaultEmissionManagerTest is Test {
         emissionManager.mint();
         // timeElapsed is zero, so no minting
         assertEq(polygon.balanceOf(stakeManager), 0);
-        assertEq(matic.balanceOf(stakeManager), 0);
         assertEq(polygon.balanceOf(treasury), 0);
     }
 
@@ -145,9 +144,7 @@ contract DefaultEmissionManagerTest is Test {
         assertApproxEqAbs(newSupply, polygon.totalSupply(), _MAX_PRECISION_DELTA);
         uint256 totalAmtMinted = polygon.totalSupply() - initialTotalSupply;
         uint256 totalAmtMintedOneThird = totalAmtMinted / 3;
-        assertEq(matic.balanceOf(stakeManager), totalAmtMinted - totalAmtMintedOneThird);
-        assertEq(matic.balanceOf(treasury), 0);
-        assertEq(polygon.balanceOf(stakeManager), 0);
+        assertEq(polygon.balanceOf(stakeManager), totalAmtMinted - totalAmtMintedOneThird);
         assertEq(polygon.balanceOf(treasury), totalAmtMintedOneThird);
     }
 
@@ -166,8 +163,7 @@ contract DefaultEmissionManagerTest is Test {
         assertApproxEqAbs(newSupply, polygon.totalSupply(), _MAX_PRECISION_DELTA);
         uint256 balance = (polygon.totalSupply() - initialTotalSupply) / 3;
         uint256 stakeManagerBalance = (polygon.totalSupply() - initialTotalSupply) - balance;
-        assertEq(matic.balanceOf(stakeManager), stakeManagerBalance);
-        assertEq(polygon.balanceOf(stakeManager), 0);
+        assertEq(polygon.balanceOf(stakeManager), stakeManagerBalance);
         assertEq(polygon.balanceOf(treasury), balance);
 
         initialTotalSupply = polygon.totalSupply(); // for the new run
@@ -185,8 +181,7 @@ contract DefaultEmissionManagerTest is Test {
         balance += totalAmtMintedOneThird;
         stakeManagerBalance += totalAmtMinted - totalAmtMintedOneThird;
 
-        assertEq(matic.balanceOf(stakeManager), stakeManagerBalance);
-        assertEq(polygon.balanceOf(stakeManager), 0);
+        assertEq(polygon.balanceOf(stakeManager), stakeManagerBalance);
         assertEq(polygon.balanceOf(treasury), balance);
     }
 
@@ -213,8 +208,7 @@ contract DefaultEmissionManagerTest is Test {
             balance += totalAmtMintedOneThird;
             stakeManagerBalance += totalAmtMinted - totalAmtMintedOneThird;
 
-            assertEq(matic.balanceOf(stakeManager), stakeManagerBalance);
-            assertEq(polygon.balanceOf(stakeManager), 0);
+            assertEq(polygon.balanceOf(stakeManager), stakeManagerBalance);
             assertEq(polygon.balanceOf(treasury), balance);
         }
     }


### PR DESCRIPTION
We will no longer need to convert POL to MATIC before sending it there.

This PR changes that, so that now POL will be directly sent to the StakeManager.
The StakeManager is fine with receiving POL and will switch to using only POL internally soon.