### PR TITLE
feat: change emission to 2 percent

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -13,6 +13,7 @@ fs_permissions = [
   { access = "read", path = "script/1.1.0/input.json" },
   { access = "read", path = "script/1.2.0/input.json" },
   { access = "read", path = "script/1.3.0/input.json" },
+  { access = "read", path = "script/1.4.0/input.json" },
 ]
 
 [rpc_endpoints]

--- a/script/1.4.0/UpgradeEmissionManager.s.sol
+++ b/script/1.4.0/UpgradeEmissionManager.s.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Script, stdJson, console2 as console} from "forge-std/Script.sol";
+
+import {
+    ProxyAdmin,
+    TransparentUpgradeableProxy,
+    ITransparentUpgradeableProxy
+} from "openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+import {DefaultEmissionManager} from "../../src/DefaultEmissionManager.sol";
+
+contract UpgradeEmissionManager is Script {
+    using stdJson for string;
+
+    uint256 deployerPrivateKey = uint256(uint160(address(this))); // default placeholder for tests
+
+    string input = vm.readFile("script/1.4.0/input.json");
+    string chainIdSlug = string(abi.encodePacked('["', vm.toString(block.chainid), '"]'));
+    address emProxyAddress = input.readAddress(string.concat(chainIdSlug, ".emissionManagerProxy"));
+    address emProxyAdmin = input.readAddress(string.concat(chainIdSlug, ".emProxyAdmin"));
+
+    DefaultEmissionManager emProxy = DefaultEmissionManager(emProxyAddress);
+
+    function run() public {
+        deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        bytes memory payload = upgradeEM();
+
+        console.log("Send this payload to: ", emProxyAdmin);
+        console.logBytes(payload);
+    }
+
+    function upgradeEM() public returns (bytes memory) {
+        vm.startBroadcast(deployerPrivateKey);
+
+        address migration = address(emProxy.migration());
+        address stakeManager = emProxy.stakeManager();
+        address treasury = emProxy.treasury();
+
+        DefaultEmissionManager newEmImpl = new DefaultEmissionManager(migration, stakeManager, treasury);
+
+        vm.stopBroadcast();
+        bytes memory data = abi.encodeCall(DefaultEmissionManager.reinitialize, ());
+        bytes memory payload = abi.encodeWithSelector(
+            ProxyAdmin.upgradeAndCall.selector, ITransparentUpgradeableProxy(address(emProxy)), address(newEmImpl), data
+        );
+
+        return payload;
+    }
+}

--- a/script/1.4.0/input.json
+++ b/script/1.4.0/input.json
@@ -1,0 +1,14 @@
+{
+    "1": {
+        "emissionManagerProxy": "0xbC9f74b3b14f460a6c47dCdDFd17411cBc7b6c53",
+        "emProxyAdmin": "0xEBea33f2c92D03556b417F4F572B2FbbE62C39c3"
+    },
+    "11155111": {
+        "emissionManagerProxy": "0x20393fF3B3C38b72a16eB7d7A474cd38ABD8Ff27",
+        "emProxyAdmin": "0x28cDCE6FfE44D03da1F7b15b474a0e72243873F2"
+    },
+    "31337": {
+        "emissionManagerProxy": "0xbC9f74b3b14f460a6c47dCdDFd17411cBc7b6c53",
+        "emProxyAdmin": "0xEBea33f2c92D03556b417F4F572B2FbbE62C39c3"
+    }
+}

--- a/src/DefaultEmissionManager.sol
+++ b/src/DefaultEmissionManager.sol
@@ -11,12 +11,12 @@ import {PowUtil} from "./lib/PowUtil.sol";
 /// @title Default Emission Manager
 /// @author Polygon Labs (@DhairyaSethi, @gretzke, @qedk, @simonDos)
 /// @notice A default emission manager implementation for the Polygon ERC20 token contract on Ethereum L1
-/// @dev The contract allows for a 2.5% mint per year (compounded). 1.5% staking layer and 1% treasury
+/// @dev The contract allows for a 2% mint per year (compounded). 1% staking layer and 1% treasury
 /// @custom:security-contact security@polygon.technology
 contract DefaultEmissionManager is Ownable2StepUpgradeable, IDefaultEmissionManager {
     using SafeERC20 for IPolygonEcosystemToken;
 
-    uint256 public constant INTEREST_PER_YEAR_LOG2 = 0.03562390973072122e18; // log2(1.025)
+    uint256 public constant INTEREST_PER_YEAR_LOG2 = 0.02856915219677089e18; // log2(1.02)
     uint256 public constant START_SUPPLY = 10_000_000_000e18;
     address private immutable DEPLOYER;
 
@@ -27,8 +27,8 @@ contract DefaultEmissionManager is Ownable2StepUpgradeable, IDefaultEmissionMana
     IPolygonEcosystemToken public token;
     uint256 public startTimestamp;
 
-    // NEW STORAGE 1.2.0
-    uint256 public START_SUPPLY_1_2_0;
+    // NEW STORAGE 1.4.0, overwriting 1.2.0
+    uint256 public START_SUPPLY_1_4_0;
 
     constructor(address migration_, address stakeManager_, address treasury_) {
         if (migration_ == address(0) || stakeManager_ == address(0) || treasury_ == address(0)) revert InvalidAddress();
@@ -41,8 +41,8 @@ contract DefaultEmissionManager is Ownable2StepUpgradeable, IDefaultEmissionMana
         _disableInitializers();
     }
 
-    function reinitialize() external reinitializer(2) {
-        START_SUPPLY_1_2_0 = token.totalSupply();
+    function reinitialize() external reinitializer(3) {
+        START_SUPPLY_1_4_0 = token.totalSupply();
         startTimestamp = block.timestamp;
     }
 
@@ -70,8 +70,8 @@ contract DefaultEmissionManager is Ownable2StepUpgradeable, IDefaultEmissionMana
         uint256 amountToMint = newSupply - currentSupply;
         if (amountToMint == 0) return; // no minting required
 
-        // 2/5 of 2.5% is 1% going to the treasury
-        uint256 treasuryAmt = amountToMint * 2 / 5;
+        // 1/2 of 2% is 1% going to the treasury
+        uint256 treasuryAmt = amountToMint / 2;
         uint256 stakeManagerAmt = amountToMint - treasuryAmt;
 
         emit TokenMint(amountToMint, msg.sender);
@@ -87,12 +87,12 @@ contract DefaultEmissionManager is Ownable2StepUpgradeable, IDefaultEmissionMana
     /// @inheritdoc IDefaultEmissionManager
     function inflatedSupplyAfter(uint256 timeElapsed) public view returns (uint256 supply) {
         uint256 supplyFactor = PowUtil.exp2((INTEREST_PER_YEAR_LOG2 * timeElapsed) / 365 days);
-        supply = (supplyFactor * START_SUPPLY_1_2_0) / 1e18;
+        supply = (supplyFactor * START_SUPPLY_1_4_0) / 1e18;
     }
 
     /// @inheritdoc IDefaultEmissionManager
     function version() external pure returns (string memory) {
-        return "1.3.0";
+        return "1.4.0";
     }
 
     uint256[47] private __gap;

--- a/test/DefaultEmissionManager.t.sol
+++ b/test/DefaultEmissionManager.t.sol
@@ -72,7 +72,7 @@ contract DefaultEmissionManagerTest is Test {
         emissionManager.initialize(address(0), address(0));
     }
 
-    function test_Deployment() external {
+    function test_Deployment() view external {
         assertEq(address(emissionManager.token()), address(polygon));
         assertEq(emissionManager.stakeManager(), stakeManager);
         assertEq(emissionManager.treasury(), treasury);
@@ -146,7 +146,7 @@ contract DefaultEmissionManagerTest is Test {
 
         assertApproxEqAbs(newSupply, polygon.totalSupply(), _MAX_PRECISION_DELTA);
         uint256 totalAmtMinted = polygon.totalSupply() - initialTotalSupply;
-        uint256 totalAmtMintedTwoFifth = totalAmtMinted * 2 / 5;
+        uint256 totalAmtMintedTwoFifth = totalAmtMinted / 2;
         assertEq(polygon.balanceOf(stakeManager), totalAmtMinted - totalAmtMintedTwoFifth);
         assertEq(polygon.balanceOf(treasury), totalAmtMintedTwoFifth);
     }
@@ -165,7 +165,7 @@ contract DefaultEmissionManagerTest is Test {
         uint256 newSupply = abi.decode(vm.ffi(inputs), (uint256));
 
         assertApproxEqAbs(newSupply, polygon.totalSupply(), _MAX_PRECISION_DELTA);
-        uint256 balance = (polygon.totalSupply() - initialTotalSupply) * 2 / 5;
+        uint256 balance = (polygon.totalSupply() - initialTotalSupply) / 2;
         uint256 stakeManagerBalance = (polygon.totalSupply() - initialTotalSupply) - balance;
         assertEq(polygon.balanceOf(stakeManager), stakeManagerBalance);
         assertEq(matic.balanceOf(stakeManager), 0);
@@ -180,7 +180,7 @@ contract DefaultEmissionManagerTest is Test {
 
         assertApproxEqAbs(newSupply, polygon.totalSupply(), _MAX_PRECISION_DELTA);
         uint256 totalAmtMinted = polygon.totalSupply() - initialTotalSupply;
-        uint256 totalAmtMintedTwoFifth = totalAmtMinted * 2 / 5;
+        uint256 totalAmtMintedTwoFifth = totalAmtMinted / 2;
 
         balance = totalAmtMintedTwoFifth;
         stakeManagerBalance = totalAmtMinted - totalAmtMintedTwoFifth;
@@ -208,7 +208,7 @@ contract DefaultEmissionManagerTest is Test {
 
             assertApproxEqAbs(newSupply, polygon.totalSupply(), _MAX_PRECISION_DELTA);
             uint256 totalAmtMinted = polygon.totalSupply() - initialTotalSupply;
-            uint256 totalAmtMintedTwoFifth = totalAmtMinted * 2 / 5;
+            uint256 totalAmtMintedTwoFifth = totalAmtMinted / 2;
 
             balance = totalAmtMintedTwoFifth;
             stakeManagerBalance = totalAmtMinted - totalAmtMintedTwoFifth;

--- a/test/PolygonEcosystemToken.t.sol
+++ b/test/PolygonEcosystemToken.t.sol
@@ -41,7 +41,7 @@ contract PolygonTest is Test {
         emissionManager.initialize(address(polygon), msg.sender);
     }
 
-    function test_Deployment(address owner) external {
+    function test_Deployment(address owner) view external {
         assertEq(polygon.name(), "Polygon Ecosystem Token");
         assertEq(polygon.symbol(), "POL");
         assertEq(polygon.decimals(), 18);

--- a/test/PolygonMigration.t.sol
+++ b/test/PolygonMigration.t.sol
@@ -55,7 +55,7 @@ contract PolygonMigrationTest is Test {
         migration.acceptOwnership(); // governance accepts ownership
     }
 
-    function test_Deployment() external {
+    function test_Deployment() view external {
         assertEq(address(migration.polygon()), address(polygon));
         assertEq(address(migration.matic()), address(matic));
         assertEq(migration.owner(), governance);

--- a/test/upgrade/DefaultEmissionManager.1.4.0.mainnet.t.sol
+++ b/test/upgrade/DefaultEmissionManager.1.4.0.mainnet.t.sol
@@ -11,10 +11,11 @@ import {
     ITransparentUpgradeableProxy
 } from "openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
 import {Test} from "forge-std/Test.sol";
+import {UpgradeEmissionManager} from "script/1.4.0/UpgradeEmissionManager.s.sol";
 
 // this test forks mainnet and tests the upgradeability of DefaultEmissionManagerProxy
 
-contract DefaultEmissionManagerTestMainnet is Test {
+contract DefaultEmissionManagerTestMainnet is Test, UpgradeEmissionManager {
     uint256 mainnetFork;
 
     address POLYGON_PROTOCOL_COUNCIL = 0x37D085ca4a24f6b29214204E8A8666f12cf19516;
@@ -23,9 +24,7 @@ contract DefaultEmissionManagerTestMainnet is Test {
     address EM_PROXY_ADMIN = 0xEBea33f2c92D03556b417F4F572B2FbbE62C39c3;
     PolygonEcosystemToken pol = PolygonEcosystemToken(0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6);
 
-    uint256 NEW_INTEREST_PER_YEAR_LOG2 = 0.03562390973072122e18; // log2(1.025)
-
-    string[] internal inputs = new string[](5);
+    uint256 NEW_INTEREST_PER_YEAR_LOG2 = 0.02856915219677089e18; // log2(1.02)
 
     function setUp() public {
         mainnetFork = vm.createFork(vm.rpcUrl("mainnet"));
@@ -34,31 +33,21 @@ contract DefaultEmissionManagerTestMainnet is Test {
     function testUpgrade() external {
         vm.selectFork(mainnetFork);
 
-        DefaultEmissionManager emProxy = DefaultEmissionManager(EM_PROXY);
-
-        assertEq(emProxy.treasury(), COMMUNITY_TREASURY);
-
-        address migration = address(emProxy.migration());
-        address stakeManager = emProxy.stakeManager();
-        address treasury = emProxy.treasury();
-
-        DefaultEmissionManager newEmImpl = new DefaultEmissionManager(migration, stakeManager, treasury);
-
-        ProxyAdmin admin = ProxyAdmin(EM_PROXY_ADMIN);
+        bytes memory payload = upgradeEM();
 
         vm.prank(POLYGON_PROTOCOL_COUNCIL);
+        (bool success, /* */) = payable(EM_PROXY_ADMIN).call{value: 0}(payload);
+        vm.assertTrue(success);
 
-        admin.upgrade(
-            ITransparentUpgradeableProxy(address(emProxy)),
-            address(newEmImpl)
-        );
+        vm.assertEq(emProxy.START_SUPPLY_1_4_0(), pol.totalSupply());
+        vm.assertEq(emProxy.INTEREST_PER_YEAR_LOG2(), NEW_INTEREST_PER_YEAR_LOG2);
 
-        // minting in POL from now on
-        uint256 currentPolBalance = pol.balanceOf(address(stakeManager));
-
+        address stakeManager = emProxy.stakeManager();
+        uint256 currentPolBalance = pol.balanceOf(stakeManager);
+        vm.warp(block.timestamp + 1 days);
         emProxy.mint();
-        uint256 newPolBalance = pol.balanceOf(address(stakeManager));
+        uint256 newPolBalance = pol.balanceOf(stakeManager);
 
-        assert(newPolBalance > currentPolBalance);
+        vm.assertTrue(newPolBalance > currentPolBalance);
     }
 }

--- a/test/util/calc.js
+++ b/test/util/calc.js
@@ -1,4 +1,4 @@
-const emissionRatePerYear = 1.025;
+const emissionRatePerYear = 1.02;
 
 function main() {
     const [timeElapsedInSeconds] = process.argv.slice(2);


### PR DESCRIPTION
<h1>Adjust Emission Rate according to PIP 26</h1>

This PR implements changes necessary to comply with [PIP 26](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-26.md). 

It adjusts the POL emission rate down from 2.5 to 2%.  
The 0.5% are taken from the amount going to the StakeManager while the amount going to the Community Treasury stays the same.

This upgrade will go together with a [PR](https://github.com/0xPolygon/pos-contracts/pull/32) in the StakeManager to adjust the `CHECKPOINT_REWARD`.  

 